### PR TITLE
some improvements to molecule rendering

### DIFF
--- a/mlddec/utils.py
+++ b/mlddec/utils.py
@@ -21,23 +21,34 @@ for model in glob.glob("*.model"):
                 joblib.dump(tree, "./epsilon_4/{}_{}.model".format(model.split(".")[0], idx), compress = 9)
 #############################################
 """
+import rdkit
+from rdkit import Chem
+
 
 def validate_models(model_dict, epsilon):
     import numpy as np
-    from rdkit import Chem
     import tqdm
     try:
-        smiles = np.load(_get_data_filename("validated_results/test_smiles.npy"), allow_pickle = True)
-        charges =np.load(_get_data_filename("validated_results/test_charges_{}.npy".format(epsilon)), allow_pickle = True)
+        smiles = np.load(
+            _get_data_filename("validated_results/test_smiles.npy"),
+            allow_pickle=True)
+        charges = np.load(_get_data_filename(
+            "validated_results/test_charges_{}.npy".format(epsilon)),
+                          allow_pickle=True)
     except ValueError:
         raise ValueError("No model for epsilon value of {}".format(epsilon))
 
-    print("Checking through molecule dataset, stops when discrepencies are observed...")
-    for s,c in tqdm.tqdm(list(zip(smiles, charges))):
-        if np.any(~np.isclose(get_charges(Chem.AddHs(Chem.MolFromSmiles(s)), model_dict) , c, atol = 0.01)):
-            print("No close match for {}, validation terminated.".format(smiles))
+    print(
+        "Checking through molecule dataset, stops when discrepencies are observed..."
+    )
+    for s, c in tqdm.tqdm(list(zip(smiles, charges))):
+        if np.any(~np.isclose(get_charges(Chem.AddHs(Chem.MolFromSmiles(s)),
+                                          model_dict),
+                              c,
+                              atol=0.01)):
+            print(
+                "No close match for {}, validation terminated.".format(smiles))
             return
-
 
 
 def _get_data_filename(relative_path):
@@ -54,10 +65,13 @@ def _get_data_filename(relative_path):
     from pkg_resources import resource_filename
     fn = resource_filename('mlddec', os.path.join('data', relative_path))
     if not os.path.exists(fn):
-        raise ValueError("Sorry! %s does not exist. If you just added it, you'll have to re-install" % fn)
+        raise ValueError(
+            "Sorry! %s does not exist. If you just added it, you'll have to re-install"
+            % fn)
     return fn
 
-def load_models(epsilon = 4):
+
+def load_models(epsilon=4):
     # from sklearn.externals import joblib
     import joblib
     # supported elements (atomic numbers)
@@ -75,14 +89,31 @@ def load_models(epsilon = 4):
     print("Loading models...")
     try:
         if progress_bar:
-            rf = {element : [joblib.load(_get_data_filename("epsilon_{}/{}_{}.model".format(epsilon, elementdict[element], i))) for i in range(100)] for element in tqdm.tqdm(element_list)}
+            rf = {
+                element: [
+                    joblib.load(
+                        _get_data_filename("epsilon_{}/{}_{}.model".format(
+                            epsilon, elementdict[element], i)))
+                    for i in range(100)
+                ]
+                for element in tqdm.tqdm(element_list)
+            }
 
         else:
-            rf = {element : [joblib.load(_get_data_filename("epsilon_{}/{}_{}.model".format(epsilon, elementdict[element], i))) for i in range(100)] for element in element_list}
+            rf = {
+                element: [
+                    joblib.load(
+                        _get_data_filename("epsilon_{}/{}_{}.model".format(
+                            epsilon, elementdict[element], i)))
+                    for i in range(100)
+                ]
+                for element in element_list
+            }
 
     except ValueError:
         raise ValueError("No model for epsilon value of {}".format(epsilon))
     return rf
+
 
 def get_charges(mol, model_dict):
     """
@@ -108,43 +139,53 @@ def get_charges(mol, model_dict):
     # check for unknown elements
     curr_element_list = []
     for at in mol.GetAtoms():
-      element = at.GetAtomicNum()
-      if element not in element_list:
-          raise ValueError("Error: element {} has not been parameterised".format(element))
-      curr_element_list.append(element)
+        element = at.GetAtomicNum()
+        if element not in element_list:
+            raise ValueError(
+                "Error: element {} has not been parameterised".format(element))
+        curr_element_list.append(element)
     curr_element_list = set(curr_element_list)
 
-    pred_q = [0]*num_atoms
-    sd_rf = [0]*num_atoms
+    pred_q = [0] * num_atoms
+    sd_rf = [0] * num_atoms
     # loop over the atoms
     for i in range(num_atoms):
-      # generate atom-centered AP fingerprint
-      fp = AllChem.GetHashedAtomPairFingerprintAsBitVect(mol, maxLength=APLength, fromAtoms=[i])
-      arr = np.zeros(1,)
-      DataStructs.ConvertToNumpyArray(fp, arr)
-      # get the prediction by each tree in the forest
-      element = mol.GetAtomWithIdx(i).GetAtomicNum()
-      per_tree_pred = [tree.predict(arr.reshape(1,-1)) for tree in model_dict[element]]
-      # then average to get final predicted charge
-      pred_q[i] = np.average(per_tree_pred)
-      # and get the standard deviation, which will be used for correction
-      sd_rf[i] = np.std(per_tree_pred)
+        # generate atom-centered AP fingerprint
+        fp = AllChem.GetHashedAtomPairFingerprintAsBitVect(mol,
+                                                           maxLength=APLength,
+                                                           fromAtoms=[i])
+        arr = np.zeros(1, )
+        DataStructs.ConvertToNumpyArray(fp, arr)
+        # get the prediction by each tree in the forest
+        element = mol.GetAtomWithIdx(i).GetAtomicNum()
+        per_tree_pred = [
+            tree.predict(arr.reshape(1, -1)) for tree in model_dict[element]
+        ]
+        # then average to get final predicted charge
+        pred_q[i] = np.average(per_tree_pred)
+        # and get the standard deviation, which will be used for correction
+        sd_rf[i] = np.std(per_tree_pred)
 
     #########################
     # CORRECT EXCESS CHARGE #
     #########################
 
     # calculate excess charge
-    deltaQ = sum(pred_q)- float(AllChem.GetFormalCharge(mol))
+    deltaQ = sum(pred_q) - float(AllChem.GetFormalCharge(mol))
     charge_abs = 0.0
     for i in range(num_atoms):
-      charge_abs += sd_rf[i] * abs(pred_q[i])
+        charge_abs += sd_rf[i] * abs(pred_q[i])
     deltaQ /= charge_abs
     # correct the partial charges
 
-    return [(pred_q[i] - abs(pred_q[i]) * sd_rf[i] * deltaQ) for i in range(num_atoms)]
+    return [(pred_q[i] - abs(pred_q[i]) * sd_rf[i] * deltaQ)
+            for i in range(num_atoms)]
 
-def add_charges_to_mol(mol, model_dict = None,  charges = None, property_name = "PartialCharge"):
+
+def add_charges_to_mol(mol,
+                       model_dict=None,
+                       charges=None,
+                       property_name="PartialCharge"):
     """
     if charges is None, perform fitting using `get_charges`, for this `model_dict` needs to be provided
     """
@@ -152,12 +193,12 @@ def add_charges_to_mol(mol, model_dict = None,  charges = None, property_name = 
         assert mol.GetNumAtoms() == len(charges)
     elif charges is None and model_dict is not None:
         charges = get_charges(mol, model_dict)
-    for i,atm in enumerate(mol.GetAtoms()):
+    for i, atm in enumerate(mol.GetAtoms()):
         atm.SetDoubleProp(property_name, charges[i])
     return mol
 
 
-def _draw_mol_with_property( mol, property, **kwargs ):
+def _draw_mol_with_property(mol, property, use_similarity_map=False, **kwargs):
     """
     http://rdkit.blogspot.com/2015/02/new-drawing-code.html
 
@@ -169,37 +210,54 @@ def _draw_mol_with_property( mol, property, **kwargs ):
     from rdkit.Chem import Draw
     from rdkit.Chem import AllChem
 
-    def run_from_ipython():
+    def run_from_jupyter():
         try:
-            __IPYTHON__
-            return True
-        except NameError:
+            from IPython import get_ipython
+            if 'IPKernelApp' not in get_ipython().config:  # pragma: no cover
+                return False
+        except ImportError:
             return False
-
+        return True
 
     AllChem.Compute2DCoords(mol)
-    for idx in property:
-        # opts.atomLabels[idx] =
-        mol.GetAtomWithIdx( idx ).SetProp( 'molAtomMapNumber', "({})".format( str(property[idx])))
-
-    mol = Draw.PrepareMolForDrawing(mol, kekulize=False) #enable adding stereochem
-
-    if run_from_ipython():
-        from IPython.display import SVG, display
-        if "width" in kwargs and type(kwargs["width"]) is int and "height" in kwargs and type(kwargs["height"]) is int:
-            drawer = Draw.MolDraw2DSVG(kwargs["width"], kwargs["height"])
+    if not use_similarity_map:
+        if rdkit.__version__ >= '2020.09.1':
+            pn = 'atomNote'
         else:
-            drawer = Draw.MolDraw2DSVG(500,250)
-        drawer.DrawMolecule(mol)
+            pn = 'molAtomMapNumber'
+        for idx in property:
+            mol.GetAtomWithIdx(idx).SetProp(pn, f"({property[idx]})")
+    else:
+        from rdkit.Chem.Draw import SimilarityMaps
+        weights = [
+            float(property.get(idx, 0)) for idx in range(mol.GetNumAtoms())
+        ]
+
+    mol = Draw.PrepareMolForDrawing(mol,
+                                    kekulize=False)  #enable adding stereochem
+
+    w = kwargs.get('width', 500)
+    h = kwargs.get('height', 250)
+    if run_from_jupyter():
+        from IPython.display import SVG, display
+        drawer = Draw.MolDraw2DSVG(w, h)
+        if not use_similarity_map:
+            drawer.DrawMolecule(mol)
+        else:
+            SimilarityMaps.GetSimilarityMapFromWeights(mol,
+                                                       weights,
+                                                       draw2d=drawer)
         drawer.FinishDrawing()
         display(SVG(drawer.GetDrawingText().replace("svg:", "")))
     else:
-        if "width" in kwargs and type(kwargs["width"]) is int and "height" in kwargs and type(kwargs["height"]) is int:
-            drawer = Draw.MolDraw2DCairo(kwargs["width"], kwargs["height"])
-        else:
-            drawer = Draw.MolDraw2DCairo(500,250) #cairo requires anaconda rdkit
+        drawer = Draw.MolDraw2DCairo(w, h)  #cairo requires anaconda rdkit
         # opts = drawer.drawOptions()
-        drawer.DrawMolecule(mol)
+        if not use_similarity_map:
+            drawer.DrawMolecule(mol)
+        else:
+            SimilarityMaps.GetSimilarityMapFromWeights(mol,
+                                                       weights,
+                                                       draw2d=drawer)
         drawer.FinishDrawing()
         #
         # with open("/home/shuwang/sandbox/tmp.png","wb") as f:
@@ -219,25 +277,34 @@ def _draw_mol_with_property( mol, property, **kwargs ):
         # display(SVG(drawer.GetDrawingText()))
 
 
-def visualise_charges(mol, show_hydrogens = False, property_name = "PartialCharge" , **kwargs):
+def visualise_charges(mol,
+                      show_hydrogens=False,
+                      condense_hydrogen_charges=True,
+                      property_name="PartialCharge",
+                      drop_leading_zero=True,
+                      **kwargs):
+    if condense_hydrogen_charges and not show_hydrogens:
+        mol = Chem.Mol(mol)
+        for at in mol.GetAtoms():
+            if at.GetAtomicNum() == 1 and at.GetDegree() == 1:
+                nbr = at.GetBonds()[0].GetOtherAtom(at)
+                if nbr.GetAtomicNum() != 1:
+                    nbr.SetDoubleProp(
+                        property_name,
+                        nbr.GetDoubleProp(property_name) +
+                        at.GetDoubleProp(property_name))
     if not show_hydrogens:
-        from rdkit import Chem
         mol = Chem.RemoveHs(mol)
-
     atom_mapping = {}
-    for idx,atm in enumerate(mol.GetAtoms()):
+    for idx, atm in enumerate(mol.GetAtoms()):
         try:
             #currently only designed with partial charge in mind
-            # keeps 2.s.f, and remove starting `0.``
-            tmp =  atm.GetProp(property_name)
-            try:
-                tmp =  str("{0:.2g}".format(float(tmp)))
-                if tmp[0:3] == "-0.":
-                    tmp = "-" + tmp[2:]
-                elif tmp[0:2] == "0.":
-                    tmp = tmp[1:]
-            except:
-                pass
+            # keeps 2.s.f, and optional removes starting `0.``
+            tmp = f"{atm.GetDoubleProp(property_name):.2g}"
+            if drop_leading_zero:
+                tmp = tmp.replace('0.', '.')
+            if tmp[0] in ('0', '.'):
+                tmp = '+' + tmp
             atom_mapping[idx] = tmp
         except Exception as e:
             print("Failed at atom number {} due to {}".format(idx, e))
@@ -245,5 +312,8 @@ def visualise_charges(mol, show_hydrogens = False, property_name = "PartialCharg
     _draw_mol_with_property(mol, atom_mapping, **kwargs)
 
 
-def visualize_charges(mol, show_hydrogens = False, property_name = "PartialCharge", **kwargs ):
+def visualize_charges(mol,
+                      show_hydrogens=False,
+                      property_name="PartialCharge",
+                      **kwargs):
     return visualise_charges(mol, show_hydrogens, property_name, **kwargs)


### PR DESCRIPTION
Here's a gist demo'ing a couple of the new options:
https://gist.github.com/greglandrum/8cbfe7c41f13cd56d11335afa133a9ef

Other changes:
- I swapped the detection of ipython to look for jupyter instead
- If Hs aren't being shown I added the option to condense H charges to the atom they are connected to. I also made this the default since otherwise the results give a very misleading view of what the charge distribution looks like.
- When RDKit versions > 2020.09.1 are installed this uses atomNotes to display the charges instead of atom map numbers
- Unfortunately yapf ended up getting run automatically so there are some formatting changes in here too. If that's massively disturbing, I can revert those changes.

